### PR TITLE
qxl.testtapper.testNameSpace in Manifest.json

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -36,7 +36,7 @@
       "title": "Qooxdoo TestTAPper",
       "environment": {
         "qx.icontheme": "Tango",
-        "testtapper.testNameSpace": "qx.test"
+        "qxl.testtapper.testNameSpace": "qx.test"
       },
       "include": [
         "qx.test.*"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ $ npx qx package update
 $ npx qx package install qooxdoo/qxl.testtapper
 ```
 
-Now edit the `"myapp.test.*"` entry in your `compile.json` file to point to the
+Now replace the `"qx.test.*"` entry in `application.includes` section of your `compile.json` file to point to the
 test classes in your own application.
+Also set value for the environment variable `qxl.testtapper.testNameSpace` in your `compile.json`.
 
 ```
 $ npx qx serve


### PR DESCRIPTION
The problem: every time when I install `qxl.testtapper` in my app I have to fix environment variable name.
Bonus: added some extra hints for adoption `compile.json` for your application. I would use variable mechanism to automate these fixes  but as I get there is no means for it in qooxdoo.