### PR TITLE
fix(coverage): merge istanbul output by source-mapped path (#38)

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -218,8 +218,7 @@ qx.Class.define("qxl.testtapper.compile.LibraryApi", {
 
                   await converter.load();
                   converter.applyCoverage(entry.functions);
-                  const instanbul = converter.toIstanbul();
-                  entries[filePath] = instanbul[filePath];
+                  Object.assign(entries, converter.toIstanbul());
                 }
                 await mkdir(path.join(process.cwd(), ".nyc_output"), {
                   recursive: true,


### PR DESCRIPTION
## Problem

`qx test --coverage` writes an empty `.nyc_output/out.json` (`{}`) with current `v8-to-istanbul`, so no coverage is reported even though the tests run and `page.coverage` collects data.

The coverage writer does:

```js
const instanbul = converter.toIstanbul();
entries[filePath] = instanbul[filePath];
```

`filePath` is the transpiled path, but `toIstanbul()` keys its result by the source-map-resolved **original** source path, not the path passed to the constructor. So `instanbul[filePath]` is `undefined`, every `entries[...]` becomes `undefined`, and `JSON.stringify` drops `undefined` values — leaving `{}`.

## Fix

Merge whatever keys `toIstanbul()` returns instead of indexing by the transpiled path:

```js
Object.assign(entries, converter.toIstanbul());
```

This is robust regardless of how `toIstanbul()` keys its output. It also correctly captures a transpiled file that maps back to more than one original source (the single-key lookup could only ever pick up one), and it removes the misspelled `instanbul` local.

Fixes #38.

## Verification

Against a qooxdoo 7.9.2 app (this code path is identical in v3.0.0 and on `master`), with `v8-to-istanbul` 9.3.0: before the change `out.json` is `{}`; after it, it contains per-file istanbul data keyed by original source path and `nyc report` renders correct line/branch/function coverage.
